### PR TITLE
Make sure the "mount -o remount,rw /" is executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ root@<RMPP_IP_ADDRESS>'s password:
 ```
 **NOTE**: For the **"ssh"** command itself make sure the "Requirements" have section have been reviewed, where it was mentioned about it. <br>
 **NOTE**: The value of <RMPP_SSH_ROOT_PASSWORD> is visible from the "General > About" page of the RMPP itself. <br>
+Once we have access to the RMPP, let's also now execute this command to being able to write files into the system folders, as we would needed this later on:
+```
+root@<RMPP_IP_ADDRESS> mount -o remount,rw /
+```
 
 * **Step C)** At this point, it is needed to determine the so-called "ORIGINAL_DOC_HASH_ID" of the document that you want to use as "Calendar Memo" document. <br>
 This particular value is actually visible from the names of the folders and files within the **"/home/root/.local/share/remarkable/xochitl/"** on RMPP. <br>


### PR DESCRIPTION
Modified "README.md" to include the important command, as the first step before executing other:
```
mount -o remount,rw /
```
This is needed in order to copy into the system folders. For example:
```
cp /home/root/rm_calendar_memo/rm_calendar_memo.service /usr/lib/systemd/system/rm_calendar_memo.service
```
NOTE: What's important, this command would be reset after the RMPP "Full restart", unless we create the service that automatically executes this command on the boot. So, it is relatively safe to execute, since it can be reverted back by the RMPP, if required to revert.